### PR TITLE
Fix a segfault in release mode

### DIFF
--- a/faux_macros/src/methods/morphed.rs
+++ b/faux_macros/src/methods/morphed.rs
@@ -294,10 +294,11 @@ impl<'a> MethodData<'a> {
             }
         };
 
+        let panic_message = format!("do not call this ({})", name);
         let faux_method = syn::parse_quote! {
             #[allow(clippy::needless_arbitrary_self_type)]
             pub fn #faux_ident(self: #receiver_tokens, input: (#(#arg_types),*)) -> #output {
-                panic!("do not call this")
+                panic!(#panic_message)
             }
         };
 


### PR DESCRIPTION
Yes, that change fixes a segfault.

Turns out that in release mode some of the `_faux_originalname` functions were getting deduplicated, since they have the same inputs, same body, and always panic. So when they were cast to usize to use as a key in `MockStore`, they would point to the same `Vec<Mock>` despite being from different functions with different return types. Just changing the body to point to a different string literal is enough to prevent the deduplication, though running CI tests in release mode would probably be good to catch this if more optimizations get released. (Or use something like a per-method [`once_cell::race::OnceNonZeroUsize`](https://docs.rs/once_cell/1.7.2/once_cell/race/struct.OnceNonZeroUsize.html) and a global counter to bypass function ids entirely)
