### PR TITLE
Use a lazy static initialized with a global counter for function ids

### DIFF
--- a/faux_macros/src/methods/receiver.rs
+++ b/faux_macros/src/methods/receiver.rs
@@ -7,7 +7,6 @@ use syn::spanned::Spanned;
 pub struct Receiver {
     span: Span,
     pub kind: SelfKind,
-    pub tokens: TokenStream,
 }
 
 impl Receiver {
@@ -19,23 +18,19 @@ impl Receiver {
                     Some(Receiver {
                         kind: SelfKind::from_type(arg_ty),
                         span: arg_ty.span(),
-                        tokens: quote! { #arg_ty },
                     })
                 }
                 _ => None,
             },
             syn::FnArg::Receiver(receiver) => {
-                let (kind, tokens) = match (&receiver.reference, &receiver.mutability) {
-                    (None, _) => (SelfKind::Owned, quote! { Self }),
-                    (Some(_), None) => (SelfKind::Pointer(PointerKind::Ref), quote! { &Self }),
-                    (Some(_), Some(_)) => {
-                        (SelfKind::Pointer(PointerKind::MutRef), quote! { &mut Self })
-                    }
+                let kind = match (&receiver.reference, &receiver.mutability) {
+                    (None, _) => SelfKind::Owned,
+                    (Some(_), None) => SelfKind::Pointer(PointerKind::Ref),
+                    (Some(_), Some(_)) => SelfKind::Pointer(PointerKind::MutRef),
                 };
 
                 Some(Receiver {
                     kind,
-                    tokens,
                     span: receiver.span(),
                 })
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,7 +898,7 @@ pub use matcher::ArgMatcher;
 
 // exported so generated code can call for it
 // but purposefully not documented
-pub use mock_store::{MaybeFaux, MockStore};
+pub use mock_store::{LazyMethodId, MaybeFaux, MockStore};
 
 #[doc(include = "../README.md")]
 #[cfg(doctest)]

--- a/src/when/once.rs
+++ b/src/when/once.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::{
     matcher,
     mock::{Mock, Stub},
@@ -12,16 +14,22 @@ use crate::{
 /// Do *NOT* rely on the signature of `Once`. While changing the
 /// methods of `Once` will be considered a breaking change, changing
 /// the generics within `Once` will not.
-pub struct Once<'q, R, I, O, M: matcher::InvocationMatcher<I>> {
-    id: fn(R, I) -> O,
+pub struct Once<'q, I, O, M: matcher::InvocationMatcher<I>> {
+    id: u64,
     store: &'q mut MockStore,
     matcher: M,
+    _marker: PhantomData<fn(I) -> O>,
 }
 
-impl<'q, R, I, O, M: matcher::InvocationMatcher<I> + Send + 'static> Once<'q, R, I, O, M> {
+impl<'q, I, O, M: matcher::InvocationMatcher<I> + Send + 'static> Once<'q, I, O, M> {
     #[doc(hidden)]
-    pub fn new(id: fn(R, I) -> O, store: &'q mut MockStore, matcher: M) -> Self {
-        Once { id, store, matcher }
+    pub(super) fn new(id: u64, store: &'q mut MockStore, matcher: M) -> Self {
+        Once {
+            id,
+            store,
+            matcher,
+            _marker: PhantomData,
+        }
     }
 
     /// Analog of [When.then_return] where the value does not need to


### PR DESCRIPTION
As mentioned in #42. Not sure if the `R` type parameter in `When` needed to be kept; it seemed like it wasn't strictly necessary even with the functions-as-ids so I was wondering if there was another purpose.
