### PR TITLE
Implement Clone for MockStore

### DIFF
--- a/src/mock_store.rs
+++ b/src/mock_store.rs
@@ -26,7 +26,7 @@ use std::{
 /// implements_default(faux::MaybeFaux::Real(3));
 /// ```
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum MaybeFaux<T> {
     Real(T),
     Faux(MockStore),
@@ -35,15 +35,6 @@ pub enum MaybeFaux<T> {
 impl<T: Default> Default for MaybeFaux<T> {
     fn default() -> Self {
         MaybeFaux::Real(T::default())
-    }
-}
-
-impl<T: Clone> Clone for MaybeFaux<T> {
-    fn clone(&self) -> Self {
-        match self {
-            MaybeFaux::Real(r) => MaybeFaux::Real(r.clone()),
-            MaybeFaux::Faux(_) => panic!("cannot clone a mock"),
-        }
     }
 }
 
@@ -122,5 +113,14 @@ impl MockStore {
         assert!(!errors.is_empty());
 
         Err(errors.join("\n\n"))
+    }
+}
+
+impl Clone for MockStore {
+    fn clone(&self) -> Self {
+        let stubs = self.stubs.lock().unwrap();
+        Self {
+            stubs: Mutex::new(stubs.clone()),
+        }
     }
 }

--- a/src/mock_store.rs
+++ b/src/mock_store.rs
@@ -44,16 +44,16 @@ impl<T> MaybeFaux<T> {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[doc(hidden)]
 pub struct MockStore {
-    stubs: Mutex<HashMap<usize, Arc<Mutex<Vec<stub::Saved<'static>>>>>>,
+    stubs: Arc<Mutex<HashMap<usize, Arc<Mutex<Vec<stub::Saved<'static>>>>>>>,
 }
 
 impl MockStore {
     fn new() -> Self {
         MockStore {
-            stubs: Mutex::new(HashMap::new()),
+            stubs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -113,14 +113,5 @@ impl MockStore {
         assert!(!errors.is_empty());
 
         Err(errors.join("\n\n"))
-    }
-}
-
-impl Clone for MockStore {
-    fn clone(&self) -> Self {
-        let stubs = self.stubs.lock().unwrap();
-        Self {
-            stubs: Mutex::new(stubs.clone()),
-        }
     }
 }

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -25,8 +25,9 @@ fn can_clone_real() {
 }
 
 #[test]
-#[should_panic]
-fn cloning_mock_panics() {
-    let real = Foo::faux();
-    let _ = real.clone();
+fn can_clone_mock() {
+    let mut mock = Foo::faux();
+    let cloned = mock.clone();
+    faux::when!(mock.get()).then_return(4);
+    assert_eq!(cloned.get(), 4);
 }


### PR DESCRIPTION
In one of my projects I need to clone a struct that might be mocked. Doing this in a test currently results in a panic. This PR implements `Clone` on the `MockStore`, which allows us to remove the panic on a clone of `MaybeFaux::Faux`. I have tested it locally and it works in my codebase, but if these changes have any undesired behaviour in certain conditions please let me know and I might be able to fix it.
Alternatively, I could wrap the `Mutex` in an `Arc`, which would make it cheaper to clone the store.