### PR TITLE
Remove redundant "a" from example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ impl MyStructToMock { /* methods to mock */ }
 mod client {
     // #[faux::create] makes a struct mockable and
     // generates an associated `faux` function
-    // e.g., `UserClient::faux()` will create a a mock `UserClient` instance
+    // e.g., `UserClient::faux()` will create a mock `UserClient` instance
     #[faux::create]
     pub struct UserClient { /* data of the client */ }
 


### PR DESCRIPTION
This PR fixes a very minor typo in the README.

Anyways, this library looks very useful and I'm looking forward to trying it! :smile_cat: 