### PR TITLE
Feat: Allow generics in method return types and arguments.

### DIFF
--- a/faux_macros/src/lib.rs
+++ b/faux_macros/src/lib.rs
@@ -58,6 +58,7 @@ pub fn when(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             receiver,
             method,
             args,
+            turbofish,
             ..
         }) => {
             let when = quote::format_ident!("_when_{}", method);
@@ -69,7 +70,8 @@ pub fn when(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
             match args {
                 Err(e) => e.write_errors().into(),
-                Ok(args) => TokenStream::from(quote!({ #receiver.#when().with_args((#(#args,)*)) }))
+                Ok(args) if args.is_empty() => { TokenStream::from(quote!({ #receiver.#when #turbofish() }))}
+                Ok(args) => { TokenStream::from(quote!({ #receiver.#when #turbofish().with_args((#(#args,)*)) }))}
             }
         }
         expr => darling::Error::custom("faux::when! only accepts arguments in the format of: `when!(receiver.method)` or `receiver.method(args...)`")

--- a/faux_macros/src/methods/morphed.rs
+++ b/faux_macros/src/methods/morphed.rs
@@ -363,12 +363,11 @@ impl<'a> MethodData<'a> {
         let output = output.unwrap_or(&empty);
         let name_str = name.to_string();
 
-        let generics_contents = &generics.params;
-
-        let maybe_comma = if generics_contents.is_empty() {
-            quote! {}
+        let generics_contents = if generics.params.is_empty() {
+            None
         } else {
-            quote! { , }
+            let params = &generics.params;
+            Some(quote! { , #params })
         };
 
         let generics_where_clause = &generics.where_clause;
@@ -377,7 +376,7 @@ impl<'a> MethodData<'a> {
         let turbofish = turbofish(&generic_idents);
 
         let when_method = syn::parse_quote! {
-            pub fn #when_ident<'m #maybe_comma #generics_contents>(&'m mut self) -> faux::When<'m, #receiver_ty, (#(#arg_types),*), #output, faux::matcher::AnyInvocation> #generics_where_clause {
+            pub fn #when_ident<'m #generics_contents>(&'m mut self) -> faux::When<'m, #receiver_ty, (#(#arg_types),*), #output, faux::matcher::AnyInvocation> #generics_where_clause {
                 match &mut self.0 {
                     faux::MaybeFaux::Faux(_maybe_faux_faux) => faux::When::new(
                         <Self>::#faux_ident #turbofish,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,7 +1003,7 @@ impl Faux {
     ) -> Result<O, InvocationError> {
         let mock = self.store.get(id, fn_name, generics)?;
         mock.call(input).map_err(|stub_error| InvocationError {
-            fn_name: fn_name,
+            fn_name: mock.name(),
             struct_name: self.store.struct_name,
             generics,
             stub_error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -999,11 +999,13 @@ impl Faux {
         id: fn(R, I) -> O,
         fn_name: &'static str,
         input: I,
+        generics: &'static str,
     ) -> Result<O, InvocationError> {
-        let mock = self.store.get(id, fn_name)?;
+        let mock = self.store.get(id, fn_name, generics)?;
         mock.call(input).map_err(|stub_error| InvocationError {
-            fn_name: mock.name(),
+            fn_name: fn_name,
             struct_name: self.store.struct_name,
+            generics,
             stub_error,
         })
     }
@@ -1012,22 +1014,30 @@ impl Faux {
 pub struct InvocationError {
     struct_name: &'static str,
     fn_name: &'static str,
+    generics: &'static str,
     stub_error: mock::InvocationError,
 }
 
 impl fmt::Display for InvocationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let generics = if self.generics.is_empty() {
+            String::new()
+        } else {
+            format!("<{}>", self.generics)
+        };
         match &self.stub_error {
-            mock::InvocationError::NeverStubbed => write!(
-                f,
-                "`{}::{}` was called but never stubbed",
-                self.struct_name, self.fn_name
-            ),
+            mock::InvocationError::NeverStubbed => {
+                write!(
+                    f,
+                    "`{}::{}{}` was called but never stubbed",
+                    self.struct_name, self.fn_name, generics
+                )
+            }
             mock::InvocationError::Stub(errors) => {
                 writeln!(
                     f,
-                    "`{}::{}` had no suitable stubs. Existing stubs failed because:",
-                    self.struct_name, self.fn_name
+                    "`{}::{}{}` had no suitable stubs. Existing stubs failed because:",
+                    self.struct_name, self.fn_name, generics
                 )?;
                 let mut errors = errors.iter();
                 if let Some(e) = errors.next() {

--- a/src/mock/store.rs
+++ b/src/mock/store.rs
@@ -44,6 +44,7 @@ impl<'stub> Store<'stub> {
         &self,
         id: fn(R, I) -> O,
         fn_name: &'static str,
+        generics: &'static str,
     ) -> Result<&Mock<'stub, I, O>, InvocationError> {
         match self.stubs.get(&(id as usize)).map(|m| m.as_typed()) {
             Some(mock) => {
@@ -53,6 +54,7 @@ impl<'stub> Store<'stub> {
             None => Err(InvocationError {
                 fn_name,
                 struct_name: self.struct_name,
+                generics,
                 stub_error: super::InvocationError::NeverStubbed,
             }),
         }

--- a/tests/generic_method_return.rs
+++ b/tests/generic_method_return.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::disallowed_names)]
+
+pub trait MyTrait {}
+
+#[derive(Clone, PartialEq, Debug)]
+struct Entity {}
+impl MyTrait for Entity {}
+
+#[faux::create]
+pub struct Foo {}
+
+#[faux::create]
+pub struct Bar {}
+
+
+
+#[faux::methods]
+impl Foo {
+    pub fn foo<E: MyTrait>(&self, _e: E) -> E {
+        todo!()
+    }
+    pub fn bar<E: MyTrait, F: MyTrait>(&self, _e: E, _f: F) -> Result<E, F> {
+        todo!()
+    }
+    pub fn baz<E>(&self, _e: E) -> E where E: MyTrait {
+        todo!()
+    }
+}
+
+
+#[faux::create]
+struct AsyncFoo {}
+#[faux::methods]
+impl AsyncFoo {
+    pub async fn foo<E: MyTrait>(&self, _e: E) -> E {
+        todo!()
+    }
+    pub async fn bar<E: MyTrait, F: MyTrait>(&self, _e: E, _f: F) -> Result<E, F> {
+        todo!()
+    }
+    pub async fn baz<E>(&self, _e: E) -> E where E: MyTrait {
+        todo!()
+    }
+}
+
+
+#[test]
+fn generics() {
+    let mut foo = Foo::faux();
+    faux::when!(foo.foo).then_return(Entity {});
+    assert_eq!(foo.foo(Entity {}), Entity {});
+
+    let mut bar = Foo::faux();
+    faux::when!(bar.bar).then_return(Ok::<_, Entity>(Entity {}));
+    assert_eq!(bar.bar(Entity {}, Entity {}), Ok(Entity {}));
+
+    let mut baz = Foo::faux();
+    faux::when!(baz.baz).then_return(Entity {});
+    assert_eq!(baz.baz(Entity {}), Entity {});
+}
+
+#[test]
+fn generic_tests_async() {
+    let mut foo: AsyncFoo = AsyncFoo::faux();
+    faux::when!(foo.foo).then_return(Entity {});
+
+    let mut bar = AsyncFoo::faux();
+    faux::when!(bar.bar).then_return(Ok::<_, Entity>(Entity {}));
+
+    let mut baz = AsyncFoo::faux();
+    faux::when!(baz.baz).then_return(Entity {});
+    futures::executor::block_on(async {
+        assert_eq!(foo.foo(Entity {}).await, Entity {});
+        assert_eq!(bar.bar(Entity {}, Entity {}).await, Ok(Entity {}));
+        assert_eq!(baz.baz(Entity {}).await, Entity {});
+    });
+}

--- a/tests/generic_method_return.rs
+++ b/tests/generic_method_return.rs
@@ -12,8 +12,6 @@ pub struct Foo {}
 #[faux::create]
 pub struct Bar {}
 
-
-
 #[faux::methods]
 impl Foo {
     pub fn foo<E: MyTrait>(&self, _e: E) -> E {
@@ -22,11 +20,19 @@ impl Foo {
     pub fn bar<E: MyTrait, F: MyTrait>(&self, _e: E, _f: F) -> Result<E, F> {
         todo!()
     }
-    pub fn baz<E>(&self, _e: E) -> E where E: MyTrait {
+    pub fn baz<E>(&self, _e: E) -> E
+    where
+        E: MyTrait,
+    {
+        todo!()
+    }
+    pub fn qux<E>(&self)
+    where
+        E: MyTrait,
+    {
         todo!()
     }
 }
-
 
 #[faux::create]
 struct AsyncFoo {}
@@ -38,11 +44,26 @@ impl AsyncFoo {
     pub async fn bar<E: MyTrait, F: MyTrait>(&self, _e: E, _f: F) -> Result<E, F> {
         todo!()
     }
-    pub async fn baz<E>(&self, _e: E) -> E where E: MyTrait {
+    pub async fn baz<E>(&self, _e: E) -> E
+    where
+        E: MyTrait,
+    {
+        todo!()
+    }
+    pub async fn qux<E>(&self)
+    where
+        E: MyTrait,
+    {
+        todo!()
+    }
+
+    pub async fn qux_with_arg<E>(&self, _arg: u32) -> u32
+    where
+        E: MyTrait,
+    {
         todo!()
     }
 }
-
 
 #[test]
 fn generics() {
@@ -57,6 +78,10 @@ fn generics() {
     let mut baz = Foo::faux();
     faux::when!(baz.baz).then_return(Entity {});
     assert_eq!(baz.baz(Entity {}), Entity {});
+
+    let mut qux = Foo::faux();
+    faux::when!(qux.qux::<Entity>()).then(|_| {});
+    qux.qux::<Entity>();
 }
 
 #[test]
@@ -69,9 +94,21 @@ fn generic_tests_async() {
 
     let mut baz = AsyncFoo::faux();
     faux::when!(baz.baz).then_return(Entity {});
+
+    let mut qux = AsyncFoo::faux();
+    faux::when!(qux.qux::<Entity>()).then(|_| {});
+
+    let mut qux_with_arg = AsyncFoo::faux();
+    faux::when!(qux_with_arg.qux_with_arg::<Entity>()).then(|_| 100);
+    faux::when!(qux_with_arg.qux_with_arg::<Entity>(42)).then(|_| 84);
+    faux::when!(qux_with_arg.qux_with_arg::<Entity>(43)).then(|_| 86);
     futures::executor::block_on(async {
         assert_eq!(foo.foo(Entity {}).await, Entity {});
         assert_eq!(bar.bar(Entity {}, Entity {}).await, Ok(Entity {}));
         assert_eq!(baz.baz(Entity {}).await, Entity {});
+        qux.qux::<Entity>().await;
+        assert_eq!(qux_with_arg.qux_with_arg::<Entity>(42).await, 84);
+        assert_eq!(qux_with_arg.qux_with_arg::<Entity>(43).await, 86);
+        assert_eq!(qux_with_arg.qux_with_arg::<Entity>(50).await, 100);
     });
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -69,7 +69,7 @@ fn faux_ref_output() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "`Foo::get_stuff` was called but never stubbed")]
 fn unmocked_faux_panics() {
     let mock = Foo::faux();
     mock.get_stuff();

--- a/tests/when_arguments.rs
+++ b/tests/when_arguments.rs
@@ -28,9 +28,6 @@ impl Foo {
     }
 }
 
-#[derive(Debug)]
-struct Bar(i32);
-
 #[test]
 fn no_args() {
     let mut mock = Foo::faux();


### PR DESCRIPTION
Partial fix fo [#18](https://github.com/nrxus/faux/issues/18)

This changeset allows generics to method return types and arguments.
Generic impl traits are still not supported in return position (yet?).