### PR TITLE
chore: fix elided lifetimes warning.

### DIFF
--- a/faux_macros/src/methods/morphed.rs
+++ b/faux_macros/src/methods/morphed.rs
@@ -416,7 +416,7 @@ impl MethodData<'_> {
     }
 }
 
-// traverse a type, and add the provided lifetime references that don't have any lifetime yet.
+// traverse a type, and add the provided lifetime to references that don't have any lifetime yet.
 // Eg(pseudocode): `add_lifetime(Result<Option<&str>, ()>, 'a)`
 // will return
 // `Result<Option<&'a str>, ()>`

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -24,6 +24,14 @@ impl Foo {
     pub fn ret_ref(&self, _: &u32) -> &u32 {
         &self.a
     }
+
+    pub fn ret_wrapped(&self, _: &u32) -> Option<&u32> {
+        Some(&self.a)
+    }
+
+    pub fn ret_wrapped_twice(&self, _: &u32) -> Option<Option<&u32>> {
+        Some(Some(&self.a))
+    }
 }
 
 fn load_a() -> Result<u32, Box<dyn std::error::Error>> {
@@ -66,6 +74,16 @@ fn faux_ref_output() {
     unsafe { faux::when!(mock.ret_ref).then_unchecked(|a| a) };
     let x = 30 + 30;
     assert_eq!(*mock.ret_ref(&x), 60);
+}
+
+#[test]
+fn faux_ref_wrapped_output() {
+    let mut mock = Foo::faux();
+    unsafe { faux::when!(mock.ret_wrapped).then_unchecked(|a| Some(a)) };
+    unsafe { faux::when!(mock.ret_wrapped_twice).then_unchecked(|a| Some(Some(a))) };
+    let x = 30 + 30;
+    assert_eq!(*mock.ret_wrapped(&x).unwrap(), 60);
+    assert_eq!(*mock.ret_wrapped_twice(&x).unwrap().unwrap(), 60);
 }
 
 #[test]


### PR DESCRIPTION
This changeset fixes the `ELIDED_NAMED_LIFETIMES` warnings that would display when expanding the proc macro.

In order to do this, we explicitly use `'m` on receivers, and `'_` on arguments and outputs.